### PR TITLE
Add support for hidden columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,27 @@ class MoneyLaunderingReport < Dossier::Report
 end
 ```
 
+## Hidden Columns
+
+You may override `display_column?` in your report class in order to hide columns from the formatted results. For instance, you might select an employee's ID and name in order to generate a link from their name to their profile page, without actually displaying the ID value itself:
+
+```ruby
+class EmployeeReport < Dossier::Report
+  # ...
+
+  def display_column?(name)
+    name != 'id'
+  end
+
+  def format_name(value, row)
+    url = formatter.url_formatter.url_helpers.employee_path(row['id'])
+    formatter.url_formatter.link_to(value, url)
+  end
+end
+```
+
+By default, all selected columns are displayed.
+
 ## Report Options and Footers
 
 You may want to specify parameters for a report: which columns to show, a range of dates, etc. Dossier supports this via URL parameters, anything in `params[:options]` will be passed into your report's `initialize` method and made available via the `options` reader.

--- a/lib/dossier/report.rb
+++ b/lib/dossier/report.rb
@@ -59,6 +59,10 @@ module Dossier
       value
     end
 
+    def display_column?(column)
+      true
+    end
+
     def dossier_client
       Dossier.client
     end

--- a/lib/dossier/result.rb
+++ b/lib/dossier/result.rb
@@ -52,7 +52,11 @@ module Dossier
     class Formatted < Result
 
       def headers
-        @formatted_headers ||= raw_headers.map { |h| report.format_header(h) }
+        @formatted_headers ||= raw_headers.select { |h|
+          report.display_column?(h)
+        }.map { |h|
+          report.format_header(h)
+        }
       end
 
       def each
@@ -64,7 +68,10 @@ module Dossier
           raise ArgumentError.new("#{row.inspect} must be a kind of Enumerable") 
         end
 
-        row.each_with_index.map do |value, i|
+        row.each_with_index.select { |value, i|
+          column = raw_headers.at(i)
+          report.display_column?(column)
+        }.map { |value, i|
           column = raw_headers.at(i)
           method = "format_#{column}"
 
@@ -76,7 +83,7 @@ module Dossier
           else
             report.format_column(column, value)
           end
-        end
+        }
       end
     end
 

--- a/spec/dummy/app/reports/employee_report.rb
+++ b/spec/dummy/app/reports/employee_report.rb
@@ -55,6 +55,10 @@ class EmployeeReport < Dossier::Report
     @names ||= options.fetch(:names) { [] }.dup
   end
 
+  def display_column?(name)
+    name != 'id'
+  end
+
   def format_salary(amount, row)
     return "Who's Asking?" if row[:division] == "Corporate Malfeasance"
     formatter.number_to_currency(amount)

--- a/spec/features/employee_spec.rb
+++ b/spec/features/employee_spec.rb
@@ -12,6 +12,13 @@ describe "employee report" do
       end
     end
 
+    context "hiding columns" do
+      it "does not display hidden columns" do
+        visit '/reports/employee'
+        expect(page).to_not have_content('Id')
+      end
+    end
+
     context "when a custom view exists for the report" do
 
       it "uses the custom view" do


### PR DESCRIPTION
Allow report classes to control which columns are displayed in the formatted report by overriding `display_column?(name)`.

Fixes #51 